### PR TITLE
Handled NullPointer while scraping ipinfo network.

### DIFF
--- a/src/main/java/org/koreops/tauro/cli/TauroMain.java
+++ b/src/main/java/org/koreops/tauro/cli/TauroMain.java
@@ -295,6 +295,10 @@ public class TauroMain {
     for (String host : hosts) {
 
       try {
+        if (host == null) {
+          continue;
+        }
+
         if (host.contains("/")) {
           CidrUtils cidr = new CidrUtils(host);
           host = cidr.getNetworkAddress();


### PR DESCRIPTION
# What's this PR for?
This PR handles the scenario where the last host after parsing ipinfo.io was coming up null, causing a NullPointerException in generateHosts() of TauroMain.

# What to emphasize on when reviewing?
Everything.


* last host was coming up null after scraping ipinfo network. This was
  causing a NullPointer in host generation. Handled that.