### PR TITLE
Bintray publish changes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,13 @@
 group 'org.k0r0pt.routers'
-version '1.0-SNAPSHOT'
+version '0.1.0'
 
 apply from: 'build_config/tasks.gradle'
-// apply from: 'dependencies.gradle'
 
 apply plugin: 'application'
 mainClassName = "org.koreops.tauro.cli.TauroMain"
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    // compile 'commons-codec:commons-codec:1.9'
-    // compile 'org.apache.commons:commons-collections4:4.1'
-    // compile 'org.apache.logging.log4j:log4j-api:2.9.1'
-    // compile 'org.apache.logging.log4j:log4j-core:2.9.1'
     compile 'commons-cli:commons-cli:1.4'
     compile('org.k0r0pt:netutils:1.0-SNAPSHOT') {
         changing = true


### PR DESCRIPTION
# What's this PR for?
This change is for publishing our artifacts to our bintray repository (through travis).

# Linked pull requests
common_build_config: k0r0pt/common_build_config#7
netUtils: k0r0pt/netUtils#5
rom0Decoder: k0r0pt/rom0Decoder#10
tauro-core: k0r0pt/tauro-core#3

* Added json descriptors
* Refreshed related common_build_config changes.
* Upgraded version numbers.
* Added deploy configs in travis descriptors.