### PR TITLE
Fixed resume bug and added support for masscan command generation

### DIFF
--- a/src/main/java/org/koreops/tauro/cli/TauroMain.java
+++ b/src/main/java/org/koreops/tauro/cli/TauroMain.java
@@ -81,6 +81,7 @@ public class TauroMain {
 
     if (args.length < 1) {
       CliOptsProcessor.usage();
+      return;
     }
     TauroMain mainObject;
 
@@ -93,7 +94,19 @@ public class TauroMain {
       args = ProcessManager.getArgs();
       options = CliOptsProcessor.processOptions(args);
     } else {
-      ProcessManager.saveArgs(args);
+      if (!options.containsKey(CliOptsProcessor.genMasscanOptVal)) {
+        ProcessManager.saveArgs(args);
+      }
+    }
+
+    if (options.containsKey(CliOptsProcessor.genMasscanOptVal)) {
+      if (!options.containsKey(CliOptsProcessor.networkOptVal)) {
+        Logger.error("masscan generation is currently only supported for ipinfo networks.", true);
+        CliOptsProcessor.usage();
+        return;
+      }
+
+      new IpInfoScraper(options.get(CliOptsProcessor.networkOptVal)).printMasscanCommand(options.get(CliOptsProcessor.ispOptVal));
     }
 
     if (options.containsKey(CliOptsProcessor.ispOptVal)) {
@@ -253,7 +266,9 @@ public class TauroMain {
     Logger.info("All attack threads done.", true);
 
     for (String host : checkedHosts) {
-      ProcessManager.writeOffHost(host);
+      if (host != null) {
+        ProcessManager.writeOffHost(host);
+      }
     }
 
     Logger.info("Time to start next batch.", true);

--- a/src/main/java/org/koreops/tauro/cli/opts/processor/CliOptsProcessor.java
+++ b/src/main/java/org/koreops/tauro/cli/opts/processor/CliOptsProcessor.java
@@ -44,6 +44,7 @@ public class CliOptsProcessor {
   public static final String exclusionsOptVal = "exclusions";
   public static final String resumeOptVal = "resume";
   public static final String networkOptVal = "network";
+  public static final String genMasscanOptVal = "generateMasscanCommand";
 
   private static final String hostsOpt = "h";
   private static final String ispOpt = "i";
@@ -52,6 +53,7 @@ public class CliOptsProcessor {
   private static final String exclusionsOpt = "e";
   private static final String resumeOpt = "r";
   private static final String networkOpt = "n";
+  private static final String genMasscanOpt = "m";
 
   private static final Option hostsOption;
   private static final Option ispOption;
@@ -60,6 +62,7 @@ public class CliOptsProcessor {
   private static final Option exclusionsOption;
   private static final Option resumeOption;
   private static final Option networkOption;
+  private static final Option genMasscanOption;
 
   static {
     options = (new Options());
@@ -71,6 +74,7 @@ public class CliOptsProcessor {
     portOption = new Option(portOpt, portOptVal, true, "The is the port to be targeted (Multiple port support will be coming later.");
     exclusionsOption = new Option(exclusionsOpt, exclusionsOptVal, true, "A comma separated list of hosts to be excluded from attacks.");
     exclusionsOption.setArgs(Integer.MAX_VALUE);
+    genMasscanOption = new Option(genMasscanOpt, genMasscanOptVal, false, "Generate masscan command. Needs ipinfo network option specified.");
     resumeOption = new Option(resumeOpt, resumeOptVal, false, "Resume previous scan.");
 
     options.addOption(hostsFileOption);
@@ -79,6 +83,7 @@ public class CliOptsProcessor {
     options.addOption(networkOption);
     options.addOption(portOption);
     options.addOption(exclusionsOption);
+    options.addOption(genMasscanOption);
     options.addOption(resumeOption);
   }
 
@@ -95,7 +100,7 @@ public class CliOptsProcessor {
 
     Map<String, String> parsedOpts = new HashMap<>();
 
-    if (commandLine.hasOption(resumeOptVal) || commandLine.hasOption(resumeOpt)) {
+    if ((commandLine.getOptions().length == 1) && (commandLine.hasOption(resumeOptVal) || commandLine.hasOption(resumeOpt))) {
       parsedOpts.put(resumeOptVal, null);
     } else {
       if (commandLine.hasOption(ispOptVal) || commandLine.hasOption(ispOpt)) {
@@ -120,6 +125,10 @@ public class CliOptsProcessor {
 
       if (commandLine.hasOption(exclusionsOptVal) || commandLine.hasOption(exclusionsOpt)) {
         parsedOpts.put(exclusionsOptVal, getOptionValue(exclusionsOption, commandLine));
+      }
+
+      if (commandLine.hasOption(genMasscanOptVal) || commandLine.hasOption(genMasscanOpt)) {
+        parsedOpts.put(genMasscanOptVal, getOptionValue(genMasscanOption, commandLine));
       }
     }
 


### PR DESCRIPTION
# What's this PR for?
This PR has changes to add support for masscan command generation against ipInfo network. Now `-m`/`--generateMasscanCommand` option can be used in conjunction with `-n`/`--network` option to generate a masscan command to use masscan to scan all IPs in that network and generate an output json, which can then be fed to Project-Tauro using the `-f` option to scan and scrape the up and listening routers in the network.

# What to emphasize on when reviewing?

# Linked Pull Requests
netUtils: k0r0pt/netUtils#9


* Added support for masscan command generation against ipInfo network.
* Fixed resume bug.