### PR TITLE
Returned after printing masscan output.

### DIFF
--- a/src/main/java/org/koreops/tauro/cli/TauroMain.java
+++ b/src/main/java/org/koreops/tauro/cli/TauroMain.java
@@ -107,6 +107,7 @@ public class TauroMain {
       }
 
       new IpInfoScraper(options.get(CliOptsProcessor.networkOptVal)).printMasscanCommand(options.get(CliOptsProcessor.ispOptVal));
+      return;
     }
 
     if (options.containsKey(CliOptsProcessor.ispOptVal)) {


### PR DESCRIPTION
# What's this PR for?
This PR fixes the author's stupid mistake, wherein he forgot to `return` after printing the masscan command.

# What to emphasize on when reviewing?


# Linked Pull Requests
Repo: k0r0pt/<repo-name>#PRNum


* Returned after printing masscan output.