### PR TITLE
UpdaterDao Unittests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ apply plugin: 'application'
 mainClassName = "org.koreops.tauro.cli.TauroMain"
 
 dependencies {
-    testCompile 'junit:junit:' + libraryVersions.junit
     compile 'commons-cli:commons-cli:' + libraryVersions.commonsCli
     compile('org.k0r0pt:netutils:' + libraryVersions.netutils) {
         changing = true
@@ -19,4 +18,8 @@ dependencies {
     compile('org.k0r0pt.routers:romdecoder:' + libraryVersions.romdecoder) {
         changing = true
     }
+
+    testCompile 'junit:junit:' + libraryVersions.junit
+    testCompile 'org.codehaus.groovy:groovy-all:' + libraryVersions.groovy
+    testCompile 'org.spockframework:spock-core:' + libraryVersions.spock
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,9 +1,11 @@
 ext {
     libraryVersions = [
             commonsCli            :    '1.4',
-            junit                 :    '4.12',
             netutils              :    '1.0.0',
             tauroCore             :    '1.0.0',
-            romdecoder            :    '1.0.0'
+            romdecoder            :    '1.0.0',
+            junit                 :    '4.12',
+            groovy                :    '2.4.15',
+            spock                 :    '1.2-groovy-2.4',
     ]
 }

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/BinatoneScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/BinatoneScraper.java
@@ -25,6 +25,7 @@ import org.koreops.tauro.cli.authtrial.threads.DefaultAuthTrial;
 import org.koreops.tauro.cli.dao.UpdaterDao;
 import org.koreops.tauro.cli.scraper.AbstractScraper;
 import org.koreops.tauro.cli.scraper.exception.WirelessDisabledException;
+import org.koreops.tauro.core.db.DbConnEngine;
 import org.koreops.tauro.core.exceptions.DbDriverException;
 import org.koreops.tauro.core.loggers.Logger;
 
@@ -87,7 +88,7 @@ public class BinatoneScraper extends AbstractScraper {
         }
 
         for (Map<String, String> wifiData : wifiDataList) {
-          UpdaterDao.saveStation(wifiData, host);
+          UpdaterDao.saveStation(wifiData, host, DbConnEngine.getConnection());
         }
       } catch (WirelessDisabledException ex) {
         Logger.error(host + ex.getMessage());

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/CoshipScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/CoshipScraper.java
@@ -32,6 +32,7 @@ import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
 import org.koreops.tauro.cli.scraper.AbstractScraper;
+import org.koreops.tauro.core.db.DbConnEngine;
 import org.koreops.tauro.core.exceptions.DbDriverException;
 import org.koreops.tauro.core.loggers.Logger;
 
@@ -102,7 +103,7 @@ public class CoshipScraper extends AbstractScraper {
       List<Map<String, String>> wifiDataList = this.fetchDetails(macAddr);
 
       for (Map<String, String> m : wifiDataList) {
-        UpdaterDao.saveStation(m, host);
+        UpdaterDao.saveStation(m, host, DbConnEngine.getConnection());
       }
       return true;
     } catch (IOException ex) {

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/DLinkScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/DLinkScraper.java
@@ -24,6 +24,7 @@ import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.authtrial.threads.DefaultAuthTrial;
 import org.koreops.tauro.cli.dao.UpdaterDao;
 import org.koreops.tauro.cli.scraper.AbstractScraper;
+import org.koreops.tauro.core.db.DbConnEngine;
 import org.koreops.tauro.core.exceptions.DbDriverException;
 import org.koreops.tauro.core.loggers.Logger;
 
@@ -82,7 +83,7 @@ public class DLinkScraper extends AbstractScraper {
       }
       wifiData.put("BSSID", macAddr.toLowerCase());
 
-      UpdaterDao.saveStation(wifiData, host);
+      UpdaterDao.saveStation(wifiData, host, DbConnEngine.getConnection());
       return true;
     } catch (HttpStatusException ex) {
       if ((ex.getStatusCode() != 404) && (ex.getStatusCode() != 501)) {

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/DigiflipScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/DigiflipScraper.java
@@ -26,6 +26,7 @@ import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
 import org.koreops.tauro.cli.scraper.AbstractScraper;
+import org.koreops.tauro.core.db.DbConnEngine;
 import org.koreops.tauro.core.exceptions.DbDriverException;
 import org.koreops.tauro.core.loggers.Logger;
 
@@ -199,7 +200,7 @@ public class DigiflipScraper extends AbstractScraper {
     Logger.info(host + ": Found AuthType: " + wifiData.get("AuthType"));
     Logger.info(host + ": Found Encryption: " + wifiData.get("Encryption"));
 
-    UpdaterDao.saveStation(wifiData, host);
+    UpdaterDao.saveStation(wifiData, host, DbConnEngine.getConnection());
     return true;
   }
 
@@ -276,7 +277,7 @@ public class DigiflipScraper extends AbstractScraper {
     Logger.info(host + ": Found AuthType: " + wifiData.get("AuthType"));
     Logger.info(host + ": Found Encryption: " + wifiData.get("Encryption"));
 
-    UpdaterDao.saveStation(wifiData, host);
+    UpdaterDao.saveStation(wifiData, host, DbConnEngine.getConnection());
 
     return true;
   }

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/IBallWrx300NScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/IBallWrx300NScraper.java
@@ -24,6 +24,7 @@ import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.authtrial.threads.DefaultAuthTrial;
 import org.koreops.tauro.cli.dao.UpdaterDao;
 import org.koreops.tauro.cli.scraper.AbstractScraper;
+import org.koreops.tauro.core.db.DbConnEngine;
 import org.koreops.tauro.core.exceptions.DbDriverException;
 import org.koreops.tauro.core.loggers.Logger;
 
@@ -109,7 +110,7 @@ public class IBallWrx300NScraper extends AbstractScraper {
       wifiData.put("BSSID", macAddr.toLowerCase());
       wifiData.put("SSID", ssid);
 
-      UpdaterDao.saveStation(wifiData, host);
+      UpdaterDao.saveStation(wifiData, host, DbConnEngine.getConnection());
       return true;
     } catch (HttpStatusException ex) {
       if ((ex.getStatusCode() != 404) && (ex.getStatusCode() != 501)) {

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/NewIBallBatonScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/NewIBallBatonScraper.java
@@ -24,6 +24,7 @@ import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.authtrial.threads.DefaultAuthTrial;
 import org.koreops.tauro.cli.dao.UpdaterDao;
 import org.koreops.tauro.cli.scraper.AbstractScraper;
+import org.koreops.tauro.core.db.DbConnEngine;
 import org.koreops.tauro.core.exceptions.DbDriverException;
 import org.koreops.tauro.core.loggers.Logger;
 
@@ -96,7 +97,7 @@ public class NewIBallBatonScraper extends AbstractScraper {
       }
       wifiData.put("BSSID", macAddr.toString().toLowerCase());
 
-      UpdaterDao.saveStation(wifiData, host);
+      UpdaterDao.saveStation(wifiData, host, DbConnEngine.getConnection());
       return true;
     } catch (HttpStatusException ex) {
       if ((ex.getStatusCode() != 404) && (ex.getStatusCode() != 501)) {

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/NewTpLinkScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/NewTpLinkScraper.java
@@ -26,6 +26,7 @@ import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
 import org.koreops.tauro.cli.scraper.AbstractScraper;
+import org.koreops.tauro.core.db.DbConnEngine;
 import org.koreops.tauro.core.exceptions.DbDriverException;
 import org.koreops.tauro.core.loggers.Logger;
 
@@ -213,7 +214,7 @@ public class NewTpLinkScraper extends AbstractScraper {
       Logger.info(host + ": Found AuthType: " + wifiData.get("AuthType"));
       Logger.info(host + ": Found Encryption: " + wifiData.get("Encryption"));
 
-      UpdaterDao.saveStation(wifiData, host);
+      UpdaterDao.saveStation(wifiData, host, DbConnEngine.getConnection());
 
       return true;
     } catch (IOException ex) {

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/TpLinkScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/TpLinkScraper.java
@@ -26,6 +26,7 @@ import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
 import org.koreops.tauro.cli.scraper.AbstractScraper;
+import org.koreops.tauro.core.db.DbConnEngine;
 import org.koreops.tauro.core.exceptions.DbDriverException;
 import org.koreops.tauro.core.loggers.Logger;
 
@@ -201,7 +202,7 @@ public class TpLinkScraper extends AbstractScraper {
       Logger.info(host + ": Found AuthType: " + wifiData.get("AuthType"));
       Logger.info(host + ": Found Encryption: " + wifiData.get("Encryption"));
 
-      UpdaterDao.saveStation(wifiData, host);
+      UpdaterDao.saveStation(wifiData, host, DbConnEngine.getConnection());
 
       return true;
     } catch (IOException ex) {

--- a/src/main/java/org/koreops/tauro/cli/scraper/formauth/ActBeamScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/formauth/ActBeamScraper.java
@@ -23,6 +23,7 @@ import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
 import org.koreops.tauro.cli.scraper.AbstractScraper;
+import org.koreops.tauro.core.db.DbConnEngine;
 import org.koreops.tauro.core.exceptions.DbDriverException;
 import org.koreops.tauro.core.loggers.Logger;
 
@@ -194,7 +195,7 @@ public class ActBeamScraper extends AbstractScraper {
         Logger.info(host + ": Found SSID: " + wifiData.get("SSID"));
         Logger.info(host + ": Found AuthType: " + wifiData.get("AuthType"));
         Logger.info(host + ": Found Encryption: " + wifiData.get("Encryption"));
-        UpdaterDao.saveStation(wifiData, host);
+        UpdaterDao.saveStation(wifiData, host, DbConnEngine.getConnection());
       }
 
       return true;

--- a/src/test/groovy/org/koreops/tauro/cli/dao/UpdaterDaoTest.groovy
+++ b/src/test/groovy/org/koreops/tauro/cli/dao/UpdaterDaoTest.groovy
@@ -1,0 +1,136 @@
+package org.koreops.tauro.cli.dao
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+
+class UpdaterDaoTest extends Specification {
+
+    @Shared
+    def SSID_VALUE = "H4ckMe"
+    @Shared
+    def BSSID_VALUE = "66:66:66:66:66:66"
+    @Shared
+    def HOST = "dummy_host"
+    @Shared
+    def WPA_AUTH_TYPE = "WPA"
+    @Shared
+    def OPEN_AUTH_TYPE = "OPEN"
+    @Shared
+    def ENCRYPTION = "AES"
+    @Shared
+    def KEY = "123456"
+    @Shared
+    def PHONE = "123456"
+    @Shared
+    def ISP = "deutsche telekom"
+
+    @Shared
+    def WIFI_DATA = ["SSID": SSID_VALUE, "BSSID": BSSID_VALUE, "key": KEY, "Phone": PHONE]
+
+    @Shared
+    def STATION_EXISTS = true
+
+    @Shared
+    def STATION_DOES_NOT_EXIST = false
+
+    @Shared
+    def PROTECTED_NETWORK_WIFI_DATA = ["AuthType": WPA_AUTH_TYPE, "Encryption": ENCRYPTION] + WIFI_DATA
+
+    @Shared
+    def OPEN_NETWORK_WIFI_DATA = ["AuthType": OPEN_AUTH_TYPE] + WIFI_DATA
+
+
+    def "test that the prepared statement responsible for finding a station is correctly assembled"() {
+        given: "a record of a station in the db"
+        def findStationResult = Mock(ResultSet) {
+            next() >> STATION_EXISTS
+        }
+        def findStationPreparedStatement = Mock(PreparedStatement) {
+            1 * executeQuery() >> findStationResult
+        }
+        def dbConnection = Mock(Connection) {
+            prepareStatement(UpdaterDao.FIND_STATION_SQL_STATEMENT) >> findStationPreparedStatement
+            prepareStatement(UpdaterDao.UPDATE_STATION_SQL_STATEMENT) >> Mock(PreparedStatement)
+        }
+        when: "an attempt to save a station to the db is made"
+        UpdaterDao.saveStation(WIFI_DATA, HOST, dbConnection)
+        then: "the prepared statement is correctly assembled with the rught arguments"
+        1 * findStationPreparedStatement.setString(1, BSSID_VALUE)
+        1 * findStationPreparedStatement.setString(2, SSID_VALUE)
+        2 * findStationPreparedStatement.close() // this should be called only once
+        1 * findStationResult.close()
+    }
+
+    @Unroll
+    def "Test that an existing station is correctly updated for a #description"() {
+        given:
+        def findStationResult = Mock(ResultSet) {
+            next() >> STATION_EXISTS
+        }
+        def findStationPreparedStatement = Mock(PreparedStatement) {
+            executeQuery() >> findStationResult
+        }
+        def updateStationPreparedStatement = Mock(PreparedStatement)
+
+        def dbConnection = Mock(Connection) {
+            prepareStatement(UpdaterDao.FIND_STATION_SQL_STATEMENT) >> findStationPreparedStatement
+            prepareStatement(UpdaterDao.UPDATE_STATION_SQL_STATEMENT) >> updateStationPreparedStatement
+        }
+        when:
+        UpdaterDao.setIsp(ISP)
+        UpdaterDao.saveStation(wifiData, HOST, dbConnection)
+        then:
+        1 * updateStationPreparedStatement.setString(1, expectedProtocol)
+        1 * updateStationPreparedStatement.setString(2, KEY)
+        1 * updateStationPreparedStatement.setString(3, ISP)
+        1 * updateStationPreparedStatement.setString(4, PHONE)
+        1 * updateStationPreparedStatement.setString(5, BSSID_VALUE.uncapitalize())
+        1 * updateStationPreparedStatement.setString(6, SSID_VALUE)
+        1 * updateStationPreparedStatement.execute()
+        1 * dbConnection.close()
+        2 * findStationPreparedStatement.close()
+        where:
+        wifiData                    || expectedProtocol             | description
+        PROTECTED_NETWORK_WIFI_DATA || "$WPA_AUTH_TYPE $ENCRYPTION" | "protected network"
+        OPEN_NETWORK_WIFI_DATA      || OPEN_AUTH_TYPE               | "open network"
+    }
+
+    @Unroll
+    def "Test that a station is inserted for a #description"() {
+        given:
+        def findStationResult = Mock(ResultSet) {
+            next() >> STATION_DOES_NOT_EXIST
+        }
+        def findStationPreparedStatement = Mock(PreparedStatement) {
+            executeQuery() >> findStationResult
+        }
+        def updateStationPreparedStatement = Mock(PreparedStatement)
+
+        def dbConnection = Mock(Connection) {
+            prepareStatement(UpdaterDao.FIND_STATION_SQL_STATEMENT) >> findStationPreparedStatement
+            prepareStatement(UpdaterDao.INSERT_STATION_SQL_STATEMENT) >> updateStationPreparedStatement
+        }
+        UpdaterDao.setIsp(ISP)
+        when:
+        UpdaterDao.saveStation(wifiData, HOST, dbConnection)
+        then:
+        1 * updateStationPreparedStatement.setString(1, BSSID_VALUE.uncapitalize())
+        1 * updateStationPreparedStatement.setString(2, SSID_VALUE)
+        1 * updateStationPreparedStatement.setString(3, expectedProtocol)
+        1 * updateStationPreparedStatement.setString(4, KEY)
+        1 * updateStationPreparedStatement.setString(5, ISP)
+        1 * updateStationPreparedStatement.setString(6, PHONE)
+        1 * updateStationPreparedStatement.execute()
+        1 * dbConnection.close()
+        2 * findStationPreparedStatement.close()
+        where:
+        wifiData                    || expectedProtocol             | description
+        PROTECTED_NETWORK_WIFI_DATA || "$WPA_AUTH_TYPE $ENCRYPTION" | "protected network"
+        OPEN_NETWORK_WIFI_DATA      || OPEN_AUTH_TYPE               | "open network"
+    }
+}


### PR DESCRIPTION
# What's this PR for?
Unit tests for UpdaterDao.
This PR is the second part of resolving issue: k0r0pt/Project-Tauro#10

# What to emphasize on when reviewing?
* Now the DB connection is injected into UpdaterDao for easier mocking. No need to use fancy tools to mess around with the bytecode cause of the static method call `DbConnEngine.getConnection()`.
* I took the liberty of introducing [Spock](http://spockframework.org/) framework into the project. Spock will certainly make unit testing easier and fun for sure.
* This will fail for now because there is a need to accept the Linked Pull Request.

# Linked Pull Requests
Repo: k0r0pt/common_build_config#8
