### PR TITLE
Injecting DAO service through constructor to allow easier mocking

### DIFF
--- a/src/main/java/org/koreops/tauro/cli/authtrial/threads/DefaultAuthTrial.java
+++ b/src/main/java/org/koreops/tauro/cli/authtrial/threads/DefaultAuthTrial.java
@@ -25,6 +25,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.net.def.beans.Credentials;
+import org.koreops.tauro.cli.dao.UpdaterDao;
 import org.koreops.tauro.cli.scraper.AbstractScraper;
 import org.koreops.tauro.cli.scraper.basicauth.BinatoneScraper;
 import org.koreops.tauro.cli.scraper.basicauth.CoshipScraper;
@@ -47,13 +48,15 @@ import java.net.URI;
  */
 public class DefaultAuthTrial extends AbstractAuthTrial {
 
+  private final UpdaterDao updaterDao;
+
   /**
    * Constructor for the Http Basic Auth Default Login trial.
-   *
    * @param host    The host that is being attacked
    * @param port    The port on which the HTTP server is running
+   * @param updaterDao The object responsible for Data Layer updates
    */
-  public DefaultAuthTrial(String host, String port) {
+  public DefaultAuthTrial(String host, String port, UpdaterDao updaterDao) {
     super();
     this.host = host;
     if (port != null) {
@@ -61,6 +64,7 @@ public class DefaultAuthTrial extends AbstractAuthTrial {
     } else {
       this.port = 80;
     }
+    this.updaterDao = updaterDao;
   }
 
   @Override
@@ -132,56 +136,56 @@ public class DefaultAuthTrial extends AbstractAuthTrial {
     boolean success;
 
     System.out.println("Trying Binatone Scraper.");
-    scraper = new BinatoneScraper(host, hostUrl, params);
+    scraper = new BinatoneScraper(host, hostUrl, params, updaterDao);
     success = scraper.scrape();
     if (success) {
       return;
     }
 
     System.out.println("Trying DLink Scraper.");
-    scraper = new DLinkScraper(host, hostUrl, params);
+    scraper = new DLinkScraper(host, hostUrl, params, updaterDao);
     success = scraper.scrape();
     if (success) {
       return;
     }
 
     System.out.println("Trying New iBall Baton Scraper.");
-    scraper = new NewIBallBatonScraper(host, hostUrl, params);
+    scraper = new NewIBallBatonScraper(host, hostUrl, params, updaterDao);
     success = scraper.scrape();
     if (success) {
       return;
     }
 
     System.out.println("Trying Digiflip Scraper.");
-    scraper = new DigiflipScraper(host, hostUrl, params);
+    scraper = new DigiflipScraper(host, hostUrl, params, updaterDao);
     success = scraper.scrape();
     if (success) {
       return;
     }
 
     System.out.println("Trying New TPLink Scraper.");
-    scraper = new NewTpLinkScraper(host, hostUrl, params);
+    scraper = new NewTpLinkScraper(host, hostUrl, params, updaterDao);
     success = scraper.scrape();
     if (success) {
       return;
     }
 
     System.out.println("Trying Old TPLink Scraper.");
-    scraper = new TpLinkScraper(host, hostUrl, params);
+    scraper = new TpLinkScraper(host, hostUrl, params, updaterDao);
     success = scraper.scrape();
     if (success) {
       return;
     }
 
     System.out.println("Trying COSHIP Scraper.");
-    scraper = new CoshipScraper(host, hostUrl, params);
+    scraper = new CoshipScraper(host, hostUrl, params, updaterDao);
     success = scraper.scrape();
     if (success) {
       return;
     }
 
     System.out.println("Trying iBall iB-WRX300N Scraper.");
-    scraper = new IBallWrx300NScraper(host, hostUrl, params);
+    scraper = new IBallWrx300NScraper(host, hostUrl, params, updaterDao);
     success = scraper.scrape();
     if (success) {
       return;

--- a/src/main/java/org/koreops/tauro/cli/authtrial/threads/FormAuthTrial.java
+++ b/src/main/java/org/koreops/tauro/cli/authtrial/threads/FormAuthTrial.java
@@ -22,6 +22,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.net.def.beans.Credentials;
+import org.koreops.tauro.cli.dao.UpdaterDao;
 import org.koreops.tauro.cli.scraper.AbstractScraper;
 import org.koreops.tauro.cli.scraper.formauth.ActBeamScraper;
 import org.koreops.tauro.core.loggers.Logger;
@@ -40,14 +41,15 @@ import java.util.Map;
 public class FormAuthTrial extends AbstractAuthTrial {
 
   private final String hostUrl;
+  private final UpdaterDao updaterDao;
 
   /**
    * Constructor for the Form Based Auth Default Login trial.
-   *
    * @param host    The host that is being attacked
    * @param port    The port on which the HTTP server is running
+   * @param updaterDao The object responsible for Data Layer updates
    */
-  public FormAuthTrial(String host, String port) {
+  public FormAuthTrial(String host, String port, UpdaterDao updaterDao) {
     super();
     this.host = host;
     if (port != null) {
@@ -56,6 +58,7 @@ public class FormAuthTrial extends AbstractAuthTrial {
       this.port = 80;
     }
     hostUrl = this.forgeUrl("http://", this.host, this.port, "/");
+    this.updaterDao = updaterDao;
   }
 
   @Override
@@ -172,7 +175,7 @@ public class FormAuthTrial extends AbstractAuthTrial {
     boolean success;
 
     System.out.println("Trying ActBeam Scraper.");
-    scraper = new ActBeamScraper(host, hostUrl, params);
+    scraper = new ActBeamScraper(host, hostUrl, params, updaterDao);
     success = scraper.scrape();
     if (success) {
       return;

--- a/src/main/java/org/koreops/tauro/cli/dao/UpdaterDao.java
+++ b/src/main/java/org/koreops/tauro/cli/dao/UpdaterDao.java
@@ -15,8 +15,6 @@
 
 package org.koreops.tauro.cli.dao;
 
-import org.koreops.tauro.core.db.DbConnEngine;
-import org.koreops.tauro.core.exceptions.DbDriverException;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.sql.Connection;
@@ -32,19 +30,21 @@ import java.util.Map;
  */
 public class UpdaterDao {
   private static String isp;
+  private final Connection conn;
+
+  public UpdaterDao(Connection conn) {
+    this.conn = conn;
+  }
 
   /**
    * Saves scraped Wifi station to the database.
    *
    * @param wifiData            A HashMap containing the Wifi Data (BSSID, SSID, Encryption and Key)
    * @param host                The Host for which the data is being saved (Will be used for logging purposes)
-   * @throws DbDriverException  In case of a JDBC Driver related problem (unlikely to happen).
    */
-  public static synchronized void saveStation(Map<String, String> wifiData, String host) throws DbDriverException {
+  public synchronized void saveStation(Map<String, String> wifiData, String host) {
     try {
       boolean stationExists;
-      Connection conn;
-      conn = DbConnEngine.getConnection();
       String sql;
       sql = "Select * from WirelessStations where lower(BSSID) = lower(?) and SSID = ?";
       PreparedStatement stmt = conn.prepareStatement(sql);

--- a/src/main/java/org/koreops/tauro/cli/scraper/AbstractScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/AbstractScraper.java
@@ -17,11 +17,8 @@ package org.koreops.tauro.cli.scraper;
 
 import com.gargoylesoftware.htmlunit.BrowserVersion;
 import com.gargoylesoftware.htmlunit.WebClient;
-
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.net.utils.ReachabilityUtil;
-import org.koreops.tauro.core.exceptions.DbDriverException;
-import org.koreops.tauro.core.loggers.Logger;
 
 import java.util.Arrays;
 import java.util.List;
@@ -90,13 +87,7 @@ public abstract class AbstractScraper {
   public boolean scrape() {
     while (true) {
       if (ReachabilityUtil.isReachable()) {
-        try {
-          return this.scrapeAndLog();
-        } catch (DbDriverException ex) {
-          // Well, we can't go on now, can we?
-          Logger.error("Database Driver issue. Exiting...");
-          System.exit(255);
-        }
+        return this.scrapeAndLog();
       } else {
         try {
           Thread.sleep(1000);
@@ -107,5 +98,5 @@ public abstract class AbstractScraper {
     }
   }
 
-  public abstract boolean scrapeAndLog() throws DbDriverException;
+  public abstract boolean scrapeAndLog();
 }

--- a/src/main/java/org/koreops/tauro/cli/scraper/AbstractScraperAndSaver.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/AbstractScraperAndSaver.java
@@ -3,7 +3,7 @@ package org.koreops.tauro.cli.scraper;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
 
-public abstract class AbstractScrapperAndSaver extends AbstractScraper {
+public abstract class AbstractScraperAndSaver extends AbstractScraper {
 
   protected final UpdaterDao updaterDao;
 
@@ -15,7 +15,7 @@ public abstract class AbstractScrapperAndSaver extends AbstractScraper {
    * @param params  The Authentication Cracking parameters (Credentials and other data)
    * @param updaterDao The DAO class that does the job of saving the scraped data
    */
-  public AbstractScrapperAndSaver(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
+  public AbstractScraperAndSaver(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
     super(host, hostUrl, params);
     this.updaterDao = updaterDao;
   }

--- a/src/main/java/org/koreops/tauro/cli/scraper/AbstractScrapperAndSaver.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/AbstractScrapperAndSaver.java
@@ -1,0 +1,22 @@
+package org.koreops.tauro.cli.scraper;
+
+import org.koreops.net.def.beans.AuthCrackParams;
+import org.koreops.tauro.cli.dao.UpdaterDao;
+
+public abstract class AbstractScrapperAndSaver extends AbstractScraper {
+
+  protected final UpdaterDao updaterDao;
+
+  /**
+   * AbstractScraper Constructor.
+   *
+   * @param host    The host that is to be attacked
+   * @param hostUrl The complete Url to the host's webpage
+   * @param params  The Authentication Cracking parameters (Credentials and other data)
+   * @param updaterDao The DAO class that does the job of saving the scraped data
+   */
+  public AbstractScrapperAndSaver(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
+    super(host, hostUrl, params);
+    this.updaterDao = updaterDao;
+  }
+}

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/BinatoneScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/BinatoneScraper.java
@@ -23,9 +23,8 @@ import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.authtrial.threads.DefaultAuthTrial;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScraper;
+import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
 import org.koreops.tauro.cli.scraper.exception.WirelessDisabledException;
-import org.koreops.tauro.core.exceptions.DbDriverException;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -39,14 +38,13 @@ import java.util.logging.Level;
  * Scraper module for Binatone routers.
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  */
-public class BinatoneScraper extends AbstractScraper {
-
-  public BinatoneScraper(String host, String hostUrl, AuthCrackParams params) {
-    super(host, hostUrl, params);
+public class BinatoneScraper extends AbstractScrapperAndSaver {
+  public BinatoneScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
+    super(host, hostUrl, params, updaterDao);
   }
 
   @Override
-  public boolean scrapeAndLog() throws DbDriverException {
+  public boolean scrapeAndLog() {
     return this.logWirelessStation(hostUrl, base64Login);
   }
 
@@ -57,7 +55,7 @@ public class BinatoneScraper extends AbstractScraper {
    * @param hostUrl     The complete URL, including the port number, protocol etc
    * @param base64Login The base64 login header
    */
-  private boolean logWirelessStation(String hostUrl, String base64Login) throws DbDriverException {
+  private boolean logWirelessStation(String hostUrl, String base64Login) {
     try {
       String macAddr = null;
       String devInfoUrl = hostUrl + "status/status_deviceinfo.htm";
@@ -87,7 +85,7 @@ public class BinatoneScraper extends AbstractScraper {
         }
 
         for (Map<String, String> wifiData : wifiDataList) {
-          UpdaterDao.saveStation(wifiData, host);
+          updaterDao.saveStation(wifiData, host);
         }
       } catch (WirelessDisabledException ex) {
         Logger.error(host + ex.getMessage());
@@ -102,8 +100,6 @@ public class BinatoneScraper extends AbstractScraper {
     } catch (IOException ex) {
       Logger.error(host + ": IOException during logWirelessStation(): " + ex.getMessage() + " ::::::: " + ex.getLocalizedMessage());
       java.util.logging.Logger.getLogger(DefaultAuthTrial.class.getName()).log(Level.SEVERE, null, ex);
-    } catch (DbDriverException ex) {
-      throw ex;
     } catch (Exception ex) {
       Logger.error(host + ": Exception during logWirelessStation(): " + ex.getMessage() + " ::::::: " + ex.getLocalizedMessage());
       java.util.logging.Logger.getLogger(DefaultAuthTrial.class.getName()).log(Level.SEVERE, null, ex);

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/BinatoneScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/BinatoneScraper.java
@@ -23,7 +23,7 @@ import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.authtrial.threads.DefaultAuthTrial;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
+import org.koreops.tauro.cli.scraper.AbstractScraperAndSaver;
 import org.koreops.tauro.cli.scraper.exception.WirelessDisabledException;
 import org.koreops.tauro.core.loggers.Logger;
 
@@ -38,7 +38,7 @@ import java.util.logging.Level;
  * Scraper module for Binatone routers.
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  */
-public class BinatoneScraper extends AbstractScrapperAndSaver {
+public class BinatoneScraper extends AbstractScraperAndSaver {
   public BinatoneScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
     super(host, hostUrl, params, updaterDao);
   }

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/CoshipScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/CoshipScraper.java
@@ -17,7 +17,6 @@ package org.koreops.tauro.cli.scraper.basicauth;
 
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
-
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
@@ -31,8 +30,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScraper;
-import org.koreops.tauro.core.exceptions.DbDriverException;
+import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.BufferedReader;
@@ -48,18 +46,18 @@ import java.util.Map;
  *
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  */
-public class CoshipScraper extends AbstractScraper {
+public class CoshipScraper extends AbstractScrapperAndSaver {
 
-  public CoshipScraper(String host, String hostUrl, AuthCrackParams params) {
-    super(host, hostUrl, params);
+  public CoshipScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
+    super(host, hostUrl, params, updaterDao);
   }
 
   @Override
-  public boolean scrapeAndLog() throws DbDriverException {
+  public boolean scrapeAndLog() {
     return this.logCoshipStation();
   }
 
-  private boolean logCoshipStation() throws DbDriverException {
+  private boolean logCoshipStation() {
     try {
 
       Document doc = Jsoup.connect(hostUrl).userAgent(USER_AGENT).header("Authorization", "Basic " + base64Login).timeout(60000).get();
@@ -102,7 +100,7 @@ public class CoshipScraper extends AbstractScraper {
       List<Map<String, String>> wifiDataList = this.fetchDetails(macAddr);
 
       for (Map<String, String> m : wifiDataList) {
-        UpdaterDao.saveStation(m, host);
+        updaterDao.saveStation(m, host);
       }
       return true;
     } catch (IOException ex) {
@@ -111,8 +109,6 @@ public class CoshipScraper extends AbstractScraper {
       Logger.error(host + ": FailingHttpStatusCodeException during getWirelessData(): " + ex.getMessage() + " ::::::: " + ex.toString());
     } catch (ElementNotFoundException ex) {
       Logger.error(host + ": ElementNotFoundException during getWirelessData(): " + ex.getMessage() + " ::::::: " + ex.toString());
-    } catch (DbDriverException ex) {
-      throw ex;
     } catch (Exception ex) {
       Logger.error(host + ": Exception during getWirelessData(): " + ex.getMessage() + " ::::::: " + ex.toString());
     }

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/CoshipScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/CoshipScraper.java
@@ -30,7 +30,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
+import org.koreops.tauro.cli.scraper.AbstractScraperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.BufferedReader;
@@ -46,7 +46,7 @@ import java.util.Map;
  *
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  */
-public class CoshipScraper extends AbstractScrapperAndSaver {
+public class CoshipScraper extends AbstractScraperAndSaver {
 
   public CoshipScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
     super(host, hostUrl, params, updaterDao);

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/DLinkScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/DLinkScraper.java
@@ -23,8 +23,7 @@ import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.authtrial.threads.DefaultAuthTrial;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScraper;
-import org.koreops.tauro.core.exceptions.DbDriverException;
+import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -37,18 +36,18 @@ import java.util.logging.Level;
  *
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  */
-public class DLinkScraper extends AbstractScraper {
+public class DLinkScraper extends AbstractScrapperAndSaver {
 
-  public DLinkScraper(String host, String hostUrl, AuthCrackParams params) {
-    super(host, hostUrl, params);
+  public DLinkScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
+    super(host, hostUrl, params, updaterDao);
   }
 
   @Override
-  public boolean scrapeAndLog() throws DbDriverException {
+  public boolean scrapeAndLog() {
     return this.logDLinkWirelessStation(hostUrl, base64Login);
   }
 
-  private boolean logDLinkWirelessStation(String hostUrl, String base64Login) throws DbDriverException {
+  private boolean logDLinkWirelessStation(String hostUrl, String base64Login) {
     try {
       String macAddr = null;
       String devInfoUrl = hostUrl + "info.html";
@@ -82,7 +81,7 @@ public class DLinkScraper extends AbstractScraper {
       }
       wifiData.put("BSSID", macAddr.toLowerCase());
 
-      UpdaterDao.saveStation(wifiData, host);
+      updaterDao.saveStation(wifiData, host);
       return true;
     } catch (HttpStatusException ex) {
       if ((ex.getStatusCode() != 404) && (ex.getStatusCode() != 501)) {
@@ -91,8 +90,6 @@ public class DLinkScraper extends AbstractScraper {
     } catch (IOException ex) {
       Logger.error(host + ": IOException during logWirelessStation(): " + ex.getMessage() + " ::::::: " + ex.getLocalizedMessage());
       java.util.logging.Logger.getLogger(DefaultAuthTrial.class.getName()).log(Level.SEVERE, null, ex);
-    } catch (DbDriverException ex) {
-      throw ex;
     } catch (Exception ex) {
       Logger.error(host + ": Exception during logWirelessStation(): " + ex.getMessage() + " ::::::: " + ex.getLocalizedMessage());
       java.util.logging.Logger.getLogger(DefaultAuthTrial.class.getName()).log(Level.SEVERE, null, ex);

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/DLinkScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/DLinkScraper.java
@@ -23,7 +23,7 @@ import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.authtrial.threads.DefaultAuthTrial;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
+import org.koreops.tauro.cli.scraper.AbstractScraperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -36,7 +36,7 @@ import java.util.logging.Level;
  *
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  */
-public class DLinkScraper extends AbstractScrapperAndSaver {
+public class DLinkScraper extends AbstractScraperAndSaver {
 
   public DLinkScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
     super(host, hostUrl, params, updaterDao);

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/DigiflipScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/DigiflipScraper.java
@@ -24,7 +24,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
+import org.koreops.tauro.cli.scraper.AbstractScraperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -37,7 +37,7 @@ import java.util.logging.Level;
  *
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  */
-public class DigiflipScraper extends AbstractScrapperAndSaver {
+public class DigiflipScraper extends AbstractScraperAndSaver {
 
   public DigiflipScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
     super(host, hostUrl, params, updaterDao);

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/DigiflipScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/DigiflipScraper.java
@@ -18,15 +18,13 @@ package org.koreops.tauro.cli.scraper.basicauth;
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScraper;
-import org.koreops.tauro.core.exceptions.DbDriverException;
+import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -39,18 +37,18 @@ import java.util.logging.Level;
  *
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  */
-public class DigiflipScraper extends AbstractScraper {
+public class DigiflipScraper extends AbstractScrapperAndSaver {
 
-  public DigiflipScraper(String host, String hostUrl, AuthCrackParams params) {
-    super(host, hostUrl, params);
+  public DigiflipScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
+    super(host, hostUrl, params, updaterDao);
   }
 
   @Override
-  public boolean scrapeAndLog() throws DbDriverException {
+  public boolean scrapeAndLog() {
     return this.logDigiflipStation();
   }
 
-  private boolean logDigiflipStation() throws DbDriverException {
+  private boolean logDigiflipStation()  {
     try {
       boolean newRouter = false;
 
@@ -86,8 +84,6 @@ public class DigiflipScraper extends AbstractScraper {
     } catch (ElementNotFoundException ex) {
       Logger.error(host + ": ElementNotFoundException during getWirelessData(): " + ex.getMessage() + " ::::::: " + ex.toString());
       java.util.logging.Logger.getLogger(NewTpLinkScraper.class.getName()).log(Level.SEVERE, null, ex);
-    } catch (DbDriverException ex) {
-      throw ex;
     } catch (Exception ex) {
       Logger.error(host + ": Exception during getWirelessData(): " + ex.getMessage() + " ::::::: " + ex.toString());
       java.util.logging.Logger.getLogger(NewTpLinkScraper.class.getName()).log(Level.SEVERE, null, ex);
@@ -95,7 +91,7 @@ public class DigiflipScraper extends AbstractScraper {
     return false;
   }
 
-  private boolean logNewDigiflip(HtmlPage mainPage) throws IOException, InterruptedException, DbDriverException {
+  private boolean logNewDigiflip(HtmlPage mainPage) throws IOException, InterruptedException {
     Thread.sleep(1000);     // Let the javascript load the menu.
     ((HtmlPage) mainPage.getFrameByName("menu").getEnclosedPage()).getAnchorByName("sub24").click();
     Thread.sleep(1000);     // Let the javascript load the menu.
@@ -199,11 +195,11 @@ public class DigiflipScraper extends AbstractScraper {
     Logger.info(host + ": Found AuthType: " + wifiData.get("AuthType"));
     Logger.info(host + ": Found Encryption: " + wifiData.get("Encryption"));
 
-    UpdaterDao.saveStation(wifiData, host);
+    updaterDao.saveStation(wifiData, host);
     return true;
   }
 
-  private boolean logOldDigiflip(HtmlPage mainPage) throws IOException, InterruptedException, DbDriverException {
+  private boolean logOldDigiflip(HtmlPage mainPage) throws IOException, InterruptedException {
 
     String macAddr = null;
 
@@ -276,7 +272,7 @@ public class DigiflipScraper extends AbstractScraper {
     Logger.info(host + ": Found AuthType: " + wifiData.get("AuthType"));
     Logger.info(host + ": Found Encryption: " + wifiData.get("Encryption"));
 
-    UpdaterDao.saveStation(wifiData, host);
+    updaterDao.saveStation(wifiData, host);
 
     return true;
   }

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/IBallWrx300NScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/IBallWrx300NScraper.java
@@ -23,7 +23,7 @@ import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.authtrial.threads.DefaultAuthTrial;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
+import org.koreops.tauro.cli.scraper.AbstractScraperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -37,7 +37,7 @@ import java.util.logging.Level;
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  * @since 24 Oct, 2017 10:56 PM
  */
-public class IBallWrx300NScraper extends AbstractScrapperAndSaver {
+public class IBallWrx300NScraper extends AbstractScraperAndSaver {
 
   public IBallWrx300NScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
     super(host, hostUrl, params, updaterDao);

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/IBallWrx300NScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/IBallWrx300NScraper.java
@@ -23,8 +23,7 @@ import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.authtrial.threads.DefaultAuthTrial;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScraper;
-import org.koreops.tauro.core.exceptions.DbDriverException;
+import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -38,14 +37,14 @@ import java.util.logging.Level;
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  * @since 24 Oct, 2017 10:56 PM
  */
-public class IBallWrx300NScraper extends AbstractScraper {
+public class IBallWrx300NScraper extends AbstractScrapperAndSaver {
 
-  public IBallWrx300NScraper(String host, String hostUrl, AuthCrackParams params) {
-    super(host, hostUrl, params);
+  public IBallWrx300NScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
+    super(host, hostUrl, params, updaterDao);
   }
 
   @Override
-  public boolean scrapeAndLog() throws DbDriverException {
+  public boolean scrapeAndLog() {
     return this.logIBallBatonWirelessStation(hostUrl, base64Login);
   }
 
@@ -54,7 +53,7 @@ public class IBallWrx300NScraper extends AbstractScraper {
    *
    * @param base64Login This is for iBall Baton's Router - iB-WRX300N
    */
-  private boolean logIBallBatonWirelessStation(String hostUrl, String base64Login) throws DbDriverException {
+  private boolean logIBallBatonWirelessStation(String hostUrl, String base64Login) {
     try {
       System.out.println("Cracking iBall");
       String macAddr = null;
@@ -109,7 +108,7 @@ public class IBallWrx300NScraper extends AbstractScraper {
       wifiData.put("BSSID", macAddr.toLowerCase());
       wifiData.put("SSID", ssid);
 
-      UpdaterDao.saveStation(wifiData, host);
+      updaterDao.saveStation(wifiData, host);
       return true;
     } catch (HttpStatusException ex) {
       if ((ex.getStatusCode() != 404) && (ex.getStatusCode() != 501)) {
@@ -118,8 +117,6 @@ public class IBallWrx300NScraper extends AbstractScraper {
     } catch (IOException ex) {
       Logger.error(host + ": IOException during logWirelessStation(): " + ex.getMessage() + " ::::::: " + ex.getLocalizedMessage());
       java.util.logging.Logger.getLogger(DefaultAuthTrial.class.getName()).log(Level.SEVERE, null, ex);
-    } catch (DbDriverException ex) {
-      throw ex;
     } catch (Exception ex) {
       Logger.error(host + ": Exception during logWirelessStation(): " + ex.getMessage() + " ::::::: " + ex.getLocalizedMessage());
       java.util.logging.Logger.getLogger(DefaultAuthTrial.class.getName()).log(Level.SEVERE, null, ex);

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/NewIBallBatonScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/NewIBallBatonScraper.java
@@ -23,8 +23,7 @@ import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.authtrial.threads.DefaultAuthTrial;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScraper;
-import org.koreops.tauro.core.exceptions.DbDriverException;
+import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -37,14 +36,14 @@ import java.util.logging.Level;
  *
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  */
-public class NewIBallBatonScraper extends AbstractScraper {
+public class NewIBallBatonScraper extends AbstractScrapperAndSaver {
 
-  public NewIBallBatonScraper(String host, String hostUrl, AuthCrackParams params) {
-    super(host, hostUrl, params);
+  public NewIBallBatonScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
+    super(host, hostUrl, params, updaterDao);
   }
 
   @Override
-  public boolean scrapeAndLog() throws DbDriverException {
+  public boolean scrapeAndLog() {
     return this.logIBallBatonWirelessStation(hostUrl, base64Login);
   }
 
@@ -53,7 +52,7 @@ public class NewIBallBatonScraper extends AbstractScraper {
    *
    * @param base64Login This is for iBall Baton's 300M Wi-Fi Mini AP Router - iBWRR300N
    */
-  private boolean logIBallBatonWirelessStation(String hostUrl, String base64Login) throws DbDriverException {
+  private boolean logIBallBatonWirelessStation(String hostUrl, String base64Login) {
     try {
       System.out.println("Cracking iBall");
       StringBuilder macAddr = null;
@@ -96,7 +95,7 @@ public class NewIBallBatonScraper extends AbstractScraper {
       }
       wifiData.put("BSSID", macAddr.toString().toLowerCase());
 
-      UpdaterDao.saveStation(wifiData, host);
+      updaterDao.saveStation(wifiData, host);
       return true;
     } catch (HttpStatusException ex) {
       if ((ex.getStatusCode() != 404) && (ex.getStatusCode() != 501)) {
@@ -105,8 +104,6 @@ public class NewIBallBatonScraper extends AbstractScraper {
     } catch (IOException ex) {
       Logger.error(host + ": IOException during logWirelessStation(): " + ex.getMessage() + " ::::::: " + ex.getLocalizedMessage());
       java.util.logging.Logger.getLogger(DefaultAuthTrial.class.getName()).log(Level.SEVERE, null, ex);
-    } catch (DbDriverException ex) {
-      throw ex;
     } catch (Exception ex) {
       Logger.error(host + ": Exception during logWirelessStation(): " + ex.getMessage() + " ::::::: " + ex.getLocalizedMessage());
       java.util.logging.Logger.getLogger(DefaultAuthTrial.class.getName()).log(Level.SEVERE, null, ex);

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/NewIBallBatonScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/NewIBallBatonScraper.java
@@ -23,7 +23,7 @@ import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.authtrial.threads.DefaultAuthTrial;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
+import org.koreops.tauro.cli.scraper.AbstractScraperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -36,7 +36,7 @@ import java.util.logging.Level;
  *
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  */
-public class NewIBallBatonScraper extends AbstractScrapperAndSaver {
+public class NewIBallBatonScraper extends AbstractScraperAndSaver {
 
   public NewIBallBatonScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
     super(host, hostUrl, params, updaterDao);

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/NewTpLinkScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/NewTpLinkScraper.java
@@ -24,7 +24,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
+import org.koreops.tauro.cli.scraper.AbstractScraperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -37,7 +37,7 @@ import java.util.logging.Level;
  *
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  */
-public class NewTpLinkScraper extends AbstractScrapperAndSaver {
+public class NewTpLinkScraper extends AbstractScraperAndSaver {
 
   public NewTpLinkScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
     super(host, hostUrl, params, updaterDao);

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/NewTpLinkScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/NewTpLinkScraper.java
@@ -18,15 +18,13 @@ package org.koreops.tauro.cli.scraper.basicauth;
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScraper;
-import org.koreops.tauro.core.exceptions.DbDriverException;
+import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -39,18 +37,18 @@ import java.util.logging.Level;
  *
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  */
-public class NewTpLinkScraper extends AbstractScraper {
+public class NewTpLinkScraper extends AbstractScrapperAndSaver {
 
-  public NewTpLinkScraper(String host, String hostUrl, AuthCrackParams params) {
-    super(host, hostUrl, params);
+  public NewTpLinkScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
+    super(host, hostUrl, params, updaterDao);
   }
 
   @Override
-  public boolean scrapeAndLog() throws DbDriverException {
+  public boolean scrapeAndLog() {
     return this.logNewTpLinkStation();
   }
 
-  private boolean logNewTpLinkStation() throws DbDriverException {
+  private boolean logNewTpLinkStation() {
     try {
       Document doc = Jsoup.connect(hostUrl).userAgent(USER_AGENT).header("Authorization", "Basic " + base64Login).timeout(60000).get();
 
@@ -213,7 +211,7 @@ public class NewTpLinkScraper extends AbstractScraper {
       Logger.info(host + ": Found AuthType: " + wifiData.get("AuthType"));
       Logger.info(host + ": Found Encryption: " + wifiData.get("Encryption"));
 
-      UpdaterDao.saveStation(wifiData, host);
+      updaterDao.saveStation(wifiData, host);
 
       return true;
     } catch (IOException ex) {
@@ -223,8 +221,6 @@ public class NewTpLinkScraper extends AbstractScraper {
     } catch (ElementNotFoundException ex) {
       Logger.error(host + ": ElementNotFoundException during getWirelessData(): " + ex.getMessage() + " ::::::: " + ex.toString());
       java.util.logging.Logger.getLogger(NewTpLinkScraper.class.getName()).log(Level.SEVERE, null, ex);
-    } catch (DbDriverException ex) {
-      throw ex;
     } catch (Exception ex) {
       Logger.error(host + ": Exception during getWirelessData(): " + ex.getMessage() + " ::::::: " + ex.toString());
       java.util.logging.Logger.getLogger(NewTpLinkScraper.class.getName()).log(Level.SEVERE, null, ex);

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/TpLinkScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/TpLinkScraper.java
@@ -18,15 +18,13 @@ package org.koreops.tauro.cli.scraper.basicauth;
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScraper;
-import org.koreops.tauro.core.exceptions.DbDriverException;
+import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -42,18 +40,18 @@ import java.util.logging.Level;
  *
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  */
-public class TpLinkScraper extends AbstractScraper {
+public class TpLinkScraper extends AbstractScrapperAndSaver {
 
-  public TpLinkScraper(String host, String hostUrl, AuthCrackParams params) {
-    super(host, hostUrl, params);
+  public TpLinkScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
+    super(host, hostUrl, params, updaterDao);
   }
 
   @Override
-  public boolean scrapeAndLog() throws DbDriverException {
+  public boolean scrapeAndLog() {
     return this.logNewTpLinkStation();
   }
 
-  private boolean logNewTpLinkStation() throws DbDriverException {
+  private boolean logNewTpLinkStation() {
     try {
 
       Document doc = Jsoup.connect(hostUrl).userAgent(USER_AGENT).header("Authorization", "Basic " + base64Login).timeout(60000).get();
@@ -201,7 +199,7 @@ public class TpLinkScraper extends AbstractScraper {
       Logger.info(host + ": Found AuthType: " + wifiData.get("AuthType"));
       Logger.info(host + ": Found Encryption: " + wifiData.get("Encryption"));
 
-      UpdaterDao.saveStation(wifiData, host);
+      updaterDao.saveStation(wifiData, host);
 
       return true;
     } catch (IOException ex) {
@@ -211,8 +209,6 @@ public class TpLinkScraper extends AbstractScraper {
     } catch (ElementNotFoundException ex) {
       Logger.error(host + ": ElementNotFoundException during getWirelessData(): " + ex.getMessage() + " ::::::: " + ex.toString());
       java.util.logging.Logger.getLogger(NewTpLinkScraper.class.getName()).log(Level.SEVERE, null, ex);
-    } catch (DbDriverException ex) {
-      throw ex;
     } catch (Exception ex) {
       Logger.error(host + ": Exception during getWirelessData(): " + ex.getMessage() + " ::::::: " + ex.toString());
       java.util.logging.Logger.getLogger(NewTpLinkScraper.class.getName()).log(Level.SEVERE, null, ex);

--- a/src/main/java/org/koreops/tauro/cli/scraper/basicauth/TpLinkScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/basicauth/TpLinkScraper.java
@@ -24,7 +24,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
+import org.koreops.tauro.cli.scraper.AbstractScraperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -40,7 +40,7 @@ import java.util.logging.Level;
  *
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  */
-public class TpLinkScraper extends AbstractScrapperAndSaver {
+public class TpLinkScraper extends AbstractScraperAndSaver {
 
   public TpLinkScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
     super(host, hostUrl, params, updaterDao);

--- a/src/main/java/org/koreops/tauro/cli/scraper/formauth/ActBeamScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/formauth/ActBeamScraper.java
@@ -22,7 +22,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
+import org.koreops.tauro.cli.scraper.AbstractScraperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -37,7 +37,7 @@ import java.util.Map;
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  * @since 26 Sep, 2017 8:24 PM
  */
-public class ActBeamScraper extends AbstractScrapperAndSaver {
+public class ActBeamScraper extends AbstractScraperAndSaver {
 
 
   public ActBeamScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {

--- a/src/main/java/org/koreops/tauro/cli/scraper/formauth/ActBeamScraper.java
+++ b/src/main/java/org/koreops/tauro/cli/scraper/formauth/ActBeamScraper.java
@@ -22,8 +22,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.koreops.net.def.beans.AuthCrackParams;
 import org.koreops.tauro.cli.dao.UpdaterDao;
-import org.koreops.tauro.cli.scraper.AbstractScraper;
-import org.koreops.tauro.core.exceptions.DbDriverException;
+import org.koreops.tauro.cli.scraper.AbstractScrapperAndSaver;
 import org.koreops.tauro.core.loggers.Logger;
 
 import java.io.IOException;
@@ -38,18 +37,19 @@ import java.util.Map;
  * @author Sudipto Sarkar (k0r0pt) (sudiptosarkar@visioplanet.org).
  * @since 26 Sep, 2017 8:24 PM
  */
-public class ActBeamScraper extends AbstractScraper {
+public class ActBeamScraper extends AbstractScrapperAndSaver {
 
-  public ActBeamScraper(String host, String hostUrl, AuthCrackParams params) {
-    super(host, hostUrl, params);
+
+  public ActBeamScraper(String host, String hostUrl, AuthCrackParams params, UpdaterDao updaterDao) {
+    super(host, hostUrl, params, updaterDao);
   }
 
   @Override
-  public boolean scrapeAndLog() throws DbDriverException {
+  public boolean scrapeAndLog() {
     return logActBeamWifi();
   }
 
-  private boolean logActBeamWifi() throws DbDriverException {
+  private boolean logActBeamWifi() {
     String url = hostUrl + "cgi-bin/webproc";
     try {
       Connection.Response response = Jsoup.connect(url)
@@ -194,7 +194,7 @@ public class ActBeamScraper extends AbstractScraper {
         Logger.info(host + ": Found SSID: " + wifiData.get("SSID"));
         Logger.info(host + ": Found AuthType: " + wifiData.get("AuthType"));
         Logger.info(host + ": Found Encryption: " + wifiData.get("Encryption"));
-        UpdaterDao.saveStation(wifiData, host);
+        updaterDao.saveStation(wifiData, host);
       }
 
       return true;


### PR DESCRIPTION
# What's this PR for?

Fixes #22 

This PR is to enable constructor injection of the DB related dependencies. This will allow us to easily mock the injected dependency and then test the scraper implementation.

# What to emphasize on when reviewing?

* Constructor injections.
* The new abstract class to separate the notion of scraper and one that "scrapes and saves the data" ( Not sure if this one is actually required. Might be an overkill )
